### PR TITLE
Update bootstrap-progressbar.js

### DIFF
--- a/bootstrap-progressbar.js
+++ b/bootstrap-progressbar.js
@@ -121,7 +121,7 @@
                     current_percentage = Math.round(100 * this_size / parent_size);
                     current_value = Math.round(this_size / parent_size * amount_total);
 
-                    if (current_percentage >= percentage) {
+                    if (current_percentage >= percentage || current_percentage+1 == percentage) {
                         current_percentage = percentage;
                         current_value = amount_part;
                         done();


### PR DESCRIPTION
Fix for percentage inconsistency on iOs.  Depending on the parent_size, the current_percentage sometimes get stuck at 1% less than the target percentage.
