### PR TITLE
fix attempt for bar < 100 pixels and no decrease text animation.

### DIFF
--- a/bootstrap-progressbar.js
+++ b/bootstrap-progressbar.js
@@ -106,7 +106,7 @@
                 current_percentage = Math.round(100 * this_size / parent_size);
                 current_value = Math.round(this_size / parent_size * (aria_valuemax - aria_valuemin));
 
-                if (current_percentage === percentage || intervalUpdate.prev_percentage === current_percentage) {
+                if (intervalUpdate.prev_percentage === current_percentage) {
                     current_percentage = percentage;
                     current_value = aria_valuetransitiongoal;
                     done();


### PR DESCRIPTION
This change addresses the issue where a progress bar of less than 100 pixels will show incorrect text in some situations.

I understood the problem to be that for bars with fewer than 100 pixels comparing ratios between bar pixels to the percentage of the represented fraction will not always be equal.

For example the ratio 1 / 13 as shown on a bar of 45 pixels:
1/13 = 0.076... ~= 8%
45 \* (1/13) = 3.4... ~= 3 pixels
3 pixels / 45 pixels = 0.066... ~= 7%
The code was expecting the 7% to equal 8% before terminating.
Because this condition never happens the interval function keeps running and overwrites the progress bar text even after future changes!

At first I thought different rounding would resolve it (round the 7.6 down to 7 and the 6.6 up to 7). However I think that won't work in every case.  I now prefer the included solution also because it's easier to understand.

The interval function is now named `intervalUpdate` and it stores the previous percentage of pixel transition progress in `intervalUpdate.prev_percentage` and compares this to `current_percentage`.  If these two values are equal it is assumed that no more progress is being made and so the interval will terminate.
