### PR TITLE
Allow update callback to have $this

### DIFF
--- a/bootstrap-progressbar.js
+++ b/bootstrap-progressbar.js
@@ -126,7 +126,7 @@
                 }
                 $this.attr('aria-valuenow', current_value);
 
-                update(current_percentage);
+                update(current_percentage, $this);
             }, options.refresh_speed);
         }, options.transition_delay);
     };


### PR DESCRIPTION
The **update** callback should have a `$this` context, or argument passed so it is easier to use it to traverse, and find another element to which _current_percentage_ can be displayed. This could be used when multiple progressbars are used on the same page, each placed in it's logical group.

The change is very trivial, plus to avoid breaking any existing users, I chose to add `$this` as a `2nd` argument, although personally I'd prefer to pass `$this` as the `first` argument.

An example below,
![bootstrap-progressbar-patch](https://cloud.githubusercontent.com/assets/2672835/2873328/254754ca-d3a2-11e3-997c-18e8faa0814f.png)
