### PR TITLE
Update options at runtime

### DIFF
--- a/bootstrap-progressbar.js
+++ b/bootstrap-progressbar.js
@@ -143,6 +143,10 @@
             var data = $this.data('bs.progressbar');
             var options = typeof option === 'object' && option;
 
+            if (data && options) {
+                $.extend(data.options, options);
+            }
+
             if (!data) {
                 $this.data('bs.progressbar', (data = new Progressbar(this, options)));
             }


### PR DESCRIPTION
Right now options will not get updated.
Example Code:

```
// - Everything works as espected
$('#myBar')
  .attr('data-transitiongoal', 10)
  .progress({
    done: function foo() {
      console.log('foo');
    }
  });

// - Later in time
$('#myBar')
  .attr('data-transitiongoal', 10)
  .progress({
    done: function bar() {
      // This function will never get called
      // Instead foo is used
      console.log('bar');
    }
  });
```

This pull-request will solve this issue.
